### PR TITLE
Build fixes

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,7 +1,12 @@
 import Link from "next/link";
 
-export function Footer() {
-  const currentYear = new Date().getFullYear();
+async function getCurrentYear() {
+  "use cache";
+  return new Date().getFullYear();
+}
+
+export async function Footer() {
+  const currentYear = await getCurrentYear();
 
   return (
     <footer className="w-full border-t bg-muted/50 mt-auto">


### PR DESCRIPTION
moved the new Date().getFullYear() into a tiny helper marked with "use cache", and made Footer async so it can await that cached value so the page can still prerender without errors.